### PR TITLE
feat: Implement YC startup data fetcher and SQLite storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,68 @@
-# ycpull
-A Y combinator data pull
+# YC Startup Fetcher
+
+This Go program fetches startup data batch-wise from the unofficial Y Combinator startup directory API, stores it in a local SQLite database, and prints a table of the startups.
+
+## Features
+
+- Fetches startup data from `https://ycombinator-oss.vercel.app/api/batch/{batch_name}.json`.
+- Stores data locally in an SQLite database (`yc_startups.db`).
+- Displays startup name, website, and location in a formatted table.
+- Handles duplicate entries by ignoring conflicts based on startup slug.
+
+## Prerequisites
+
+- Go (version 1.18 or later recommended)
+
+## Setup & Running
+
+1.  **Clone the repository (if you haven't already):**
+    ```bash
+    git clone <repository_url>
+    cd <repository_directory>
+    ```
+
+2.  **Tidy dependencies:**
+    The necessary dependencies (`github.com/mattn/go-sqlite3`) are listed in the `go.mod` file. They will be downloaded automatically when you build or run the program. You can also fetch them explicitly:
+    ```bash
+    go mod tidy
+    ```
+    or
+    ```bash
+    go get .
+    ```
+
+3.  **Build the program (optional):**
+    You can build an executable:
+    ```bash
+    go build -o yc_fetcher
+    ```
+    This will create an executable file named `yc_fetcher`.
+
+4.  **Run the program:**
+    You need to provide a batch name as a command-line argument. For example, to fetch data for the 'summer-2023' batch:
+
+    If you built the executable:
+    ```bash
+    ./yc_fetcher summer-2023
+    ```
+
+    Alternatively, you can run directly using `go run`:
+    ```bash
+    go run . summer-2023
+    ```
+
+    Other example batch names: `winter-2023`, `winter-2022`, `summer-2022`, etc.
+
+## Database
+
+- The program will automatically create an SQLite database file named `yc_startups.db` in the same directory where you run the command.
+- If you run the program multiple times with different batch names, the new data will be added to the same database. If a startup from a new batch pull already exists (based on its unique 'slug'), it will not be re-added.
+
+## Project Structure
+
+- `main.go`: Contains the main application logic, including command-line argument parsing and orchestration of fetching and storage. Also includes the display logic.
+- `models.go`: Defines the `Startup` data structure.
+- `fetcher.go`: Contains the logic for fetching data from the YC API.
+- `database.go`: Contains the logic for database initialization and data storage.
+- `go.mod`, `go.sum`: Go module files.
+- `yc_startups.db`: (Created after first run) The SQLite database file.

--- a/database.go
+++ b/database.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	_ "github.com/mattn/go-sqlite3" // SQLite driver
+)
+
+// InitDB initializes the SQLite database and creates the startups table if it doesn't exist.
+func InitDB(dbPath string) (*sql.DB, error) {
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database at %s: %w", dbPath, err)
+	}
+
+	createTableSQL := `
+	CREATE TABLE IF NOT EXISTS startups (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT,
+		slug TEXT UNIQUE,
+		description TEXT,
+		batch TEXT,
+		logo TEXT,
+		website TEXT,
+		tags TEXT,
+		location TEXT
+	);`
+
+	_, err = db.Exec(createTableSQL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create startups table: %w", err)
+	}
+
+	return db, nil
+}
+
+// StoreStartups inserts a slice of Startup objects into the database.
+// It converts the Tags slice into a comma-separated string for storage.
+func StoreStartups(db *sql.DB, startups []Startup) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+
+	stmt, err := tx.Prepare(`
+		INSERT INTO startups (name, slug, description, batch, logo, website, tags, location)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(slug) DO NOTHING;`) // Avoid duplicates based on slug
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("failed to prepare insert statement: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, s := range startups {
+		tagsStr := strings.Join(s.Tags, ",")
+		_, err := stmt.Exec(s.Name, s.Slug, s.Description, s.Batch, s.Logo, s.Website, tagsStr, s.Location)
+		if err != nil {
+			tx.Rollback()
+			return fmt.Errorf("failed to insert startup %s (slug: %s): %w", s.Name, s.Slug, err)
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}

--- a/fetcher.go
+++ b/fetcher.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	// No os import needed for this approach
+)
+
+// FetchBatchData fetches startup data for a given batch name from the YC API.
+func FetchBatchData(batchName string) (startups []Startup, err error) { // Named return error 'err'
+	url := fmt.Sprintf("https://ycombinator-oss.vercel.app/api/batch/%s.json", batchName)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch data from %s: %w", url, err)
+	}
+	defer func() {
+		closeErr := resp.Body.Close()
+		if closeErr != nil && err == nil { // If no other error has occurred, assign closeErr to err
+			err = fmt.Errorf("failed to close response body from %s: %w", url, closeErr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		// Important: We must return here. If we don't, 'err' will be nil,
+		// and the defer func might overwrite it with a potential resp.Body.Close() error,
+		// masking the more critical StatusCode error.
+		return nil, fmt.Errorf("failed to fetch data: status code %d for %s", resp.StatusCode, url)
+	}
+
+	body, readErr := ioutil.ReadAll(resp.Body) // Use new variable for error to avoid conflict with named return 'err'
+	if readErr != nil {
+		// Assign to 'err' directly if it's the primary error we want to return
+		err = fmt.Errorf("failed to read response body from %s: %w", url, readErr)
+		return nil, err
+	}
+
+	// Unmarshal into the named return variable 'startups'
+	unmarshalErr := json.Unmarshal(body, &startups)
+	if unmarshalErr != nil {
+		// Assign to 'err' directly
+		err = fmt.Errorf("failed to unmarshal JSON from %s: %w", url, unmarshalErr)
+		return nil, err
+	}
+
+	// If err is still nil here, the defer func might set it if resp.Body.Close() fails.
+	// Otherwise, any error encountered above (status, read, unmarshal) will be returned.
+	return startups, err
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module yc_fetcher
+
+go 1.24.3
+
+require github.com/mattn/go-sqlite3 v1.14.28 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
+github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+	"text/tabwriter" // For formatted table output
+
+	_ "github.com/mattn/go-sqlite3" // SQLite driver (already in database.go but good for explicitness if main is run alone)
+)
+
+const dbPath = "yc_startups.db"
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run . <batch_name>")
+		fmt.Println("Example: go run . summer-2023")
+		os.Exit(1)
+	}
+	batchName := os.Args[1]
+
+	log.Printf("Fetching data for batch: %s", batchName)
+	startups, err := FetchBatchData(batchName)
+	if err != nil {
+		log.Fatalf("Error fetching data: %v", err)
+	}
+	if len(startups) == 0 {
+		log.Printf("No startups found for batch %s. The API might have returned an empty list or the batch name is incorrect.", batchName)
+		// os.Exit(0) // Decide if exiting here is desired or if we should proceed to init DB anyway
+	}
+	log.Printf("Fetched %d startups from API.", len(startups))
+
+	log.Printf("Initializing database: %s", dbPath)
+	db, err := InitDB(dbPath)
+	if err != nil {
+		log.Fatalf("Error initializing database: %v", err)
+	}
+	defer db.Close()
+	log.Println("Database initialized successfully.")
+
+	log.Println("Storing startups in the database...")
+	err = StoreStartups(db, startups)
+	if err != nil {
+		log.Fatalf("Error storing startups: %v", err)
+	}
+	log.Println("Startups stored successfully.")
+
+	log.Println("Displaying startups from database:")
+	err = DisplayStartups(db)
+	if err != nil {
+		log.Fatalf("Error displaying startups: %v", err)
+	}
+}
+
+// DisplayStartups queries and prints the startup data in a table format.
+func DisplayStartups(db *sql.DB) error {
+	rows, err := db.Query("SELECT name, website, location FROM startups ORDER BY name")
+	if err != nil {
+		return fmt.Errorf("failed to query startups: %w", err)
+	}
+	defer rows.Close()
+
+	fmt.Println("\n--- YC Startups ---")
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', tabwriter.AlignRight) // Removed tabwriter.Debug
+	fmt.Fprintln(w, "Name\tWebsite\tLocation\t")
+	fmt.Fprintln(w, "----\t-------\t--------\t")
+
+	var count int
+	for rows.Next() {
+		var name, website, location string
+		if err := rows.Scan(&name, &website, &location); err != nil {
+			return fmt.Errorf("failed to scan startup row: %w", err)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t\n", name, website, location)
+		count++
+	}
+
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("error during rows iteration: %w", err)
+	}
+
+	w.Flush()
+
+	if count == 0 {
+		fmt.Println("No startups found in the database to display.")
+	} else {
+		fmt.Printf("\nDisplayed %d startups.\n", count)
+	}
+
+	return nil
+}

--- a/models.go
+++ b/models.go
@@ -1,0 +1,13 @@
+package main
+
+// Startup represents the data structure for a single startup.
+type Startup struct {
+	Name        string   `json:"name"`
+	Slug        string   `json:"slug"`
+	Description string   `json:"description"`
+	Batch       string   `json:"batch"`
+	Logo        string   `json:"logo"`
+	Website     string   `json:"website"`
+	Tags        []string `json:"tags"`
+	Location    string   `json:"location"`
+}


### PR DESCRIPTION
This commit introduces a Go application that fetches startup data from the unofficial Y Combinator API for a specified batch.

Key features:
- Fetches JSON data from endpoints like: https://ycombinator-oss.vercel.app/api/batch/summer-2023.json
- Parses the JSON data into a structured format.
- Stores the startup information (name, slug, description, batch, logo, website, tags, location) in a local SQLite database (`yc_startups.db`).
- The database schema includes a `startups` table with appropriate columns, and the `slug` is treated as a unique identifier to prevent duplicates.
- Accepts a batch name (e.g., `summer-2023`) as a command-line argument.
- Prints a formatted table to the console showing the startup name, website, and location from the database.
- Includes error handling for network requests, JSON parsing, and database operations.
- The project is structured into separate files for models (`models.go`), data fetching (`fetcher.go`), database interaction (`database.go`), and main application logic (`main.go`).
- A comprehensive README.md provides instructions on setup, build, and execution.