### PR TITLE
Switch data source to Algolia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # YC Startup Fetcher
 
-This Go program fetches startup data batch-wise from the unofficial Y Combinator startup directory API, stores it in a local SQLite database, and prints a table of the startups.
+This Go program fetches startup data batch-wise from Y Combinator's public Algolia index, stores it in a local SQLite database, and prints a table of the startups.
 
 ## Features
 
-- Fetches startup data from `https://ycombinator-oss.vercel.app/api/batch/{batch_name}.json`.
+- Fetches startup data via Algolia using the `YCCompany_production` index.
 - Stores data locally in an SQLite database (`yc_startups.db`).
 - Displays startup name, website, and location in a formatted table.
 - Handles duplicate entries by ignoring conflicts based on startup slug.
@@ -52,6 +52,7 @@ This Go program fetches startup data batch-wise from the unofficial Y Combinator
     ```
 
     Other example batch names: `winter-2023`, `winter-2022`, `summer-2022`, etc.
+    The batch names must match the format used on YC's site, e.g. `Summer 2023`.
 
 ## Database
 

--- a/fetcher.go
+++ b/fetcher.go
@@ -1,51 +1,91 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	// No os import needed for this approach
 )
 
 // FetchBatchData fetches startup data for a given batch name from the YC API.
 func FetchBatchData(batchName string) (startups []Startup, err error) { // Named return error 'err'
-	url := fmt.Sprintf("https://ycombinator-oss.vercel.app/api/batch/%s.json", batchName)
+	const (
+		appID  = "45BWZJ1SGC"
+		apiKey = "MjBjYjRiMzY0NzdhZWY0NjExY2NhZjYxMGIxYjc2MTAwNWFkNTkwNTc4NjgxYjU0YzFhYTY2ZGQ5OGY5NDMxZnJlc3RyaWN0SW5kaWNlcz0lNUIlMjJZQ0NvbXBhbnlfcHJvZHVjdGlvbiUyMiUyQyUyMllDQ29tcGFueV9CeV9MYXVuY2hfRGF0ZV9wcm9kdWN0aW9uJTIyJTVEJnRhZ0ZpbHRlcnM9JTVCJTIyeWNkY19wdWJsaWMlMjIlNUQmYW5hbHl0aWNzVGFncz0lNUIlMjJ5Y2RjJTIyJTVE"
+	)
 
-	resp, err := http.Get(url)
+	url := fmt.Sprintf("https://%s-dsn.algolia.net/1/indexes/YCCompany_production/query", appID)
+
+	query := map[string]interface{}{
+		"hitsPerPage": 1000,
+		"query":       "",
+		"filters":     fmt.Sprintf("batch:\"%s\"", batchName),
+	}
+
+	payload, err := json.Marshal(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal query JSON: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Algolia-Application-Id", appID)
+	req.Header.Set("X-Algolia-API-Key", apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch data from %s: %w", url, err)
 	}
 	defer func() {
 		closeErr := resp.Body.Close()
-		if closeErr != nil && err == nil { // If no other error has occurred, assign closeErr to err
+		if closeErr != nil && err == nil {
 			err = fmt.Errorf("failed to close response body from %s: %w", url, closeErr)
 		}
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		// Important: We must return here. If we don't, 'err' will be nil,
-		// and the defer func might overwrite it with a potential resp.Body.Close() error,
-		// masking the more critical StatusCode error.
 		return nil, fmt.Errorf("failed to fetch data: status code %d for %s", resp.StatusCode, url)
 	}
 
-	body, readErr := ioutil.ReadAll(resp.Body) // Use new variable for error to avoid conflict with named return 'err'
+	body, readErr := ioutil.ReadAll(resp.Body)
 	if readErr != nil {
-		// Assign to 'err' directly if it's the primary error we want to return
 		err = fmt.Errorf("failed to read response body from %s: %w", url, readErr)
 		return nil, err
 	}
 
-	// Unmarshal into the named return variable 'startups'
-	unmarshalErr := json.Unmarshal(body, &startups)
-	if unmarshalErr != nil {
-		// Assign to 'err' directly
-		err = fmt.Errorf("failed to unmarshal JSON from %s: %w", url, unmarshalErr)
-		return nil, err
+	var algResp struct {
+		Hits []struct {
+			Name        string   `json:"name"`
+			Slug        string   `json:"slug"`
+			Description string   `json:"long_description"`
+			Batch       string   `json:"batch"`
+			Logo        string   `json:"small_logo_thumb_url"`
+			Website     string   `json:"website"`
+			Tags        []string `json:"tags"`
+			Location    string   `json:"all_locations"`
+		} `json:"hits"`
 	}
 
-	// If err is still nil here, the defer func might set it if resp.Body.Close() fails.
-	// Otherwise, any error encountered above (status, read, unmarshal) will be returned.
+	if err = json.Unmarshal(body, &algResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON from %s: %w", url, err)
+	}
+
+	for _, h := range algResp.Hits {
+		startups = append(startups, Startup{
+			Name:        h.Name,
+			Slug:        h.Slug,
+			Description: h.Description,
+			Batch:       h.Batch,
+			Logo:        h.Logo,
+			Website:     h.Website,
+			Tags:        h.Tags,
+			Location:    h.Location,
+		})
+	}
+
 	return startups, err
 }


### PR DESCRIPTION
## Summary
- use YC's Algolia index to fetch startup data for a batch
- update README instructions for the new data source

## Testing
- `go vet ./...`
- `go build ./...`
- `go run . "Summer 2013" | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_685286bc1fd0832bbc35f49a6f082b9a